### PR TITLE
feature: add Configuration As Code compatibility [JENKINS-67330]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,12 +7,12 @@
         <relativePath />
     </parent>
 
-	<groupId>org.jenkins-ci.plugins</groupId>
+    <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>proxmox</artifactId>
     <version>0.4.3-SNAPSHOT</version>
     <packaging>hpi</packaging>
     
-	<properties>
+    <properties>
         <jenkins.version>2.303.1</jenkins.version>
         <slf4jVersion>1.7.26</slf4jVersion>
         <java.level>8</java.level>
@@ -21,7 +21,7 @@
     <name>Jenkins Proxmox plugin</name>
     <description>This plugin allows Jenkins to use Proxmox virtual machines as slaves.</description>
     <url>https://github.com/jenkinsci/proxmox-plugin</url>
-	<licenses>
+    <licenses>
         <license>
             <name>MIT License</name>
             <url>https://www.opensource.org/licenses/mit-license.php</url>
@@ -39,7 +39,7 @@
             <name>Harry Macey</name>
             <email>harry.macey@gmail.com</email>
         </developer>
-		<developer>
+        <developer>
             <id>maxhy</id>
             <name>Maxime C.</name>
             <email>maxime@islog.com</email>
@@ -47,9 +47,9 @@
     </developers>
 
     <scm>
-		<connection>scm:git:ssh://github.com/jenkinsci/proxmox-plugin.git</connection>
-		<developerConnection>scm:git:ssh://git@github.com/jenkinsci/proxmox-plugin.git</developerConnection>
-	    <url>https://github.com/jenkinsci/proxmox-plugin</url>
+        <connection>scm:git:ssh://github.com/jenkinsci/proxmox-plugin.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com/jenkinsci/proxmox-plugin.git</developerConnection>
+        <url>https://github.com/jenkinsci/proxmox-plugin</url>
       <tag>HEAD</tag>
   </scm>
 
@@ -80,17 +80,27 @@
             <version>0.3.2</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>io.jenkins</groupId>
+            <artifactId>configuration-as-code</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jenkins.configuration-as-code</groupId>
+            <artifactId>test-harness</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     
     <dependencyManagement>
-	    <dependencies>
-	        <dependency>
-	            <groupId>org.jenkins-ci.main</groupId>
-	            <artifactId>jenkins-bom</artifactId>
-	            <version>${jenkins.version}</version>
-	            <type>pom</type>
-	            <scope>import</scope>
-	        </dependency>	    
-	    </dependencies>
+        <dependencies>
+            <dependency>
+                <groupId>io.jenkins.tools.bom</groupId>
+                <artifactId>bom-2.303.x</artifactId>
+                <version>1008.vb9e22885c9cf</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
     </dependencyManagement>
 </project>

--- a/src/main/java/org/jenkinsci/plugins/proxmox/VirtualMachineSlave.java
+++ b/src/main/java/org/jenkinsci/plugins/proxmox/VirtualMachineSlave.java
@@ -1,9 +1,14 @@
 package org.jenkinsci.plugins.proxmox;
 
+import static java.util.Collections.emptyList;
+import static java.util.Optional.ofNullable;
+
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import javax.security.auth.login.LoginException;
 
@@ -49,7 +54,7 @@ public class VirtualMachineSlave extends Slave {
         super(name, nodeDescription, remoteFS, numExecutors, mode, labelString,
                 new VirtualMachineLauncher(delegateLauncher, datacenterDescription, datacenterNode, virtualMachineId,
                         snapshotName, startVM, startupWaitingPeriodSeconds, revertPolicy),
-                retentionStrategy, nodeProperties);
+                retentionStrategy, ofNullable(nodeProperties).orElse(emptyList()));
         this.datacenterDescription = datacenterDescription;
         this.datacenterNode = datacenterNode;
         this.virtualMachineId = virtualMachineId;
@@ -88,7 +93,7 @@ public class VirtualMachineSlave extends Slave {
     }
     
     public ComputerLauncher getDelegateLauncher() {
-        return ((VirtualMachineLauncher) getLauncher()).getDelegate();
+        return ((VirtualMachineLauncher) getLauncher()).getLauncher();
     }
 
     @Override

--- a/src/test/java/org/jenkinsci/plugins/proxmox/tools/ConfigurationAsCodeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/proxmox/tools/ConfigurationAsCodeTest.java
@@ -1,0 +1,83 @@
+package org.jenkinsci.plugins.proxmox.tools;
+
+import hudson.model.Computer;
+import hudson.model.Node.Mode;
+import hudson.slaves.ComputerLauncher;
+import hudson.slaves.JNLPLauncher;
+import hudson.slaves.RetentionStrategy;
+import io.jenkins.plugins.casc.ConfigurationContext;
+import io.jenkins.plugins.casc.ConfiguratorRegistry;
+import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
+import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import io.jenkins.plugins.casc.model.CNode;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.jenkinsci.plugins.proxmox.Datacenter;
+import org.jenkinsci.plugins.proxmox.VirtualMachineSlave;
+import org.jenkinsci.plugins.proxmox.VirtualMachineSlaveComputer;
+import org.jenkinsci.plugins.proxmox.VirtualMachineLauncher.RevertPolicy;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import static io.jenkins.plugins.casc.misc.Util.getJenkinsRoot;
+import static io.jenkins.plugins.casc.misc.Util.toStringFromYamlFile;
+import static io.jenkins.plugins.casc.misc.Util.toYamlString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.core.Is.is;
+
+public class ConfigurationAsCodeTest {
+
+    @ClassRule
+    @ConfiguredWithCode("configuration-as-code.yml")
+    public static JenkinsConfiguredWithCodeRule r = new JenkinsConfiguredWithCodeRule();
+
+    @Test
+    public void should_support_configuration_as_code() {
+        Datacenter cloud = (Datacenter) r.jenkins.clouds.get(0);
+        assertThat(cloud.getHostname(), is("company-proxmox"));
+        assertThat(cloud.getRealm(), is("pve"));
+        assertThat(cloud.getUsername(), is("proxmox-user"));
+        assertThat(cloud.getPassword(), is("proxmox-pass"));
+        assertThat(cloud.getIgnoreSSL(), is(true));
+
+        List<Computer> computers = Arrays.asList(r.jenkins.getComputers());
+        assertThat(computers, hasSize(2));
+        assertThat(computers.get(1), instanceOf(VirtualMachineSlaveComputer.class));
+        assertThat(computers.get(1).getNode(), instanceOf(VirtualMachineSlave.class));
+
+        VirtualMachineSlave slave = (VirtualMachineSlave) computers.get(1).getNode();
+        assertThat(slave.getLauncher(), instanceOf(JNLPLauncher.class));
+        assertThat(slave.getRetentionStrategy(), instanceOf(RetentionStrategy.Demand.class));
+        assertThat(slave.getDatacenterDescription(), is(cloud.getDatacenterDescription()));
+        assertThat(slave.getDatacenterNode(), is("proxmox-node"));
+        assertThat(slave.getLabelString(), is("proxmox-label"));
+        assertThat(slave.getMode(), is(Mode.EXCLUSIVE));
+        assertThat(slave.getNodeName(), is("proxmox-vm"));
+        assertThat(slave.getNumExecutors(), is(1));
+        assertThat(slave.getRemoteFS(), is("/home/jenkins"));
+        assertThat(slave.getRevertPolicy(), is(RevertPolicy.BEFORE_JOB));
+        assertThat(slave.getSnapshotName(), is("proxmox-snapshot"));
+        assertThat(slave.getStartVM(), is(true));
+        assertThat(slave.getStartupWaitingPeriodSeconds(), is(60));
+        assertThat(slave.getVirtualMachineId(), is(42));
+    }
+
+    @Test
+    public void should_support_configuration_export() throws Exception {
+        ConfiguratorRegistry registry = ConfiguratorRegistry.get();
+        ConfigurationContext context = new ConfigurationContext(registry);
+        final CNode cloud = getJenkinsRoot(context).get("clouds");
+
+        String exported = toYamlString(cloud);
+
+        String expected = toStringFromYamlFile(this, "expected_output.yml");
+
+        assertThat(exported, is(expected));
+    }
+}

--- a/src/test/resources/org/jenkinsci/plugins/proxmox/tools/configuration-as-code.yml
+++ b/src/test/resources/org/jenkinsci/plugins/proxmox/tools/configuration-as-code.yml
@@ -1,0 +1,32 @@
+jenkins:
+  systemMessage: "Hello World"
+  agentProtocols:
+    - "JNLP4-connect"
+  clouds:
+    - datacenter:
+        hostname: "company-proxmox"
+        ignoreSSL: true
+        password: "proxmox-pass"
+        realm: "pve"
+        username: "proxmox-user"
+  nodes:
+    - virtualMachineSlave:
+        datacenterDescription: "proxmox-user@pve - company-proxmox"
+        datacenterNode: "proxmox-node"
+        launcher:
+          jnlp
+        labelString: "proxmox-label"
+        mode: EXCLUSIVE
+        name: "proxmox-vm"
+        numExecutors: 1
+        remoteFS: "/home/jenkins"
+        retentionStrategy:
+          demand:
+            idleDelay: 1
+            inDemandDelay: 0
+        revertPolicy: BEFORE_JOB
+        snapshotName: "proxmox-snapshot"
+        startVM: true
+        startupWaitingPeriodSeconds: 60
+        virtualMachineId: 42
+        

--- a/src/test/resources/org/jenkinsci/plugins/proxmox/tools/expected_output.yml
+++ b/src/test/resources/org/jenkinsci/plugins/proxmox/tools/expected_output.yml
@@ -1,0 +1,6 @@
+- datacenter:
+    hostname: "company-proxmox"
+    ignoreSSL: true
+    password: "proxmox-pass"
+    realm: "pve"
+    username: "proxmox-user"


### PR DESCRIPTION
Main modification is to extends `DelegatingComputerLauncher` instead of `ComputerLauncher`. Property renaming is also mandatory to make Jenkins-CasC happy

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
